### PR TITLE
pixiv-api-client 元リポジトリを利用するように対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,9 +146,9 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -1692,8 +1692,9 @@
       "dev": true
     },
     "pixiv-api-client": {
-      "version": "git+ssh://git@github.com/junjanjon/pixiv-api-client.git#bef1e44aaeb0be477dff48d47c88b6cbc751a1d5",
-      "from": "git+ssh://git@github.com/junjanjon/pixiv-api-client.git#master",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/pixiv-api-client/-/pixiv-api-client-0.24.0.tgz",
+      "integrity": "sha512-Xk4M0LZ09T0a94+Y4mrc8hgYeTO5ezYaY5/NwFJu/oXWcsdtHMSuvItZZGP6g12S4g3yvYZN2bTHnFPsQFOOAg==",
       "requires": {
         "axios": ">=0.19.0",
         "blueimp-md5": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "pixiv でフォローしているユーザの作品をダウンロードします。",
   "main": "main.js",
   "dependencies": {
-    "pixiv-api-client": "git@github.com:junjanjon/pixiv-api-client.git#master",
+    "pixiv-api-client": "^0.24.0",
     "request": "^2.88.2",
     "unzipper": "^0.10.10"
   },


### PR DESCRIPTION
Fix login and add support for custom headers
https://github.com/alphasp/pixiv-api-client/pull/8